### PR TITLE
Fix Swift session paramters and auth client caching

### DIFF
--- a/ironic/common/swift.py
+++ b/ironic/common/swift.py
@@ -16,6 +16,7 @@
 
 import six
 from base64 import urlsafe_b64encode
+from functools32 import lru_cache
 from os import urandom
 from six.moves import http_client
 from six.moves.urllib import parse
@@ -29,17 +30,10 @@ from ironic.common import keystone
 from ironic.conf import CONF
 
 
-_SWIFT_SESSION = None
-
-
+@lru_cache(max_size=32)
 def get_swift_session(**session_args):
-    global _SWIFT_SESSION
-    if not _SWIFT_SESSION:
-        auth = keystone.get_auth('swift')
-        _SWIFT_SESSION = keystone.get_session('swift',
-                                              auth=auth,
-                                              **session_args)
-    return _SWIFT_SESSION
+    auth = keystone.get_auth('swift', **session_args)
+    return keystone.get_session('swift', auth=auth)
 
 
 class SwiftAPI(object):


### PR DESCRIPTION
keystone.get_session() does not understand project_domain and
project_domain_name, but keystone.get_auth() does.

Nevertheless, these parameters never come into play with the current
Swift session caching behaviour, as the first created SwiftApi()
instance is used for all Swift calls. Therefore now using a behaviour
based on the session_args.