### PR TITLE
SAP Extension: Install vsmp after the OS

### DIFF
--- a/ironic/drivers/modules/agent.py
+++ b/ironic/drivers/modules/agent.py
@@ -645,6 +645,23 @@ class AgentDeploy(CustomAgentDeploy):
         # Remove symbolic link when deploy is done.
         deploy_utils.remove_http_instance_symlink(task.node.uuid)
 
+    @METRICS.timer('AgentDeploy.sap_cc_install_vsmp_memoryone')
+    @base.deploy_step(priority=50)
+    @task_manager.require_exclusive_lock
+    def sap_cc_install_vsmp_memoryone(self, task):
+        node = task.node
+        LOG.debug("Agent sap_cc_install_vsmp_memoryone invoked for node %s.",
+                  node.uuid)
+        instance_info = node.instance_info
+        instance_traits = instance_info.get('traits', [])
+        if 'CUSTOM_VSMP_MEMORYONE' not in instance_traits:
+            LOG.debug("Instance does not require vSMP MemoryOne on node %s.",
+                       node.uuid)
+            return
+
+        client = agent_client.get_client(task)
+        client.sap_cc_install_vsmp_memoryone(task.node)
+
 
 class AgentRAID(base.RAIDInterface):
     """Implementation of RAIDInterface which uses agent ramdisk."""

--- a/ironic/drivers/modules/agent_client.py
+++ b/ironic/drivers/modules/agent_client.py
@@ -756,3 +756,24 @@ class AgentClient(object):
                 return self._command(node=node,
                                      method='rescue.finalize_rescue',
                                      params=params)
+
+    @METRICS.timer('AgentClient.sap_cc_install_vsmp_memoryone')
+    def sap_cc_install_vsmp_memoryone(self, node):
+        """SAP CC extension: installs vsmp memory one,
+        if possible and requested.
+
+        :param node: A Node object.
+        :raises: IronicException when failed to issue the request or there was
+                 a malformed response from the agent.
+        :raises: AgentAPIError when agent failed to execute specified command.
+        :raises: AgentInProgress when the command fails to execute as the agent
+                 is presently executing the prior command.
+        :returns: A dict containing command response from agent.
+                  See :func:`get_commands_status` for a command result sample.
+        """
+        try:
+            return self._command(node=node,
+                                 method='sapcc.install_vsmp_memoryone',
+                                 params={}, wait=True)
+        except exception.AgentAPIError:
+            return False


### PR DESCRIPTION
We need to install vSMP after the OS has been installed but before the node has been reboted, so that the
vSMP installer can do its work without requiring
an additional boot.