### PR TITLE
Use xena-m3 branch for sushy

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -9,7 +9,7 @@ hpOneView>=4.4.0
 
 python-dracclient>=5.1.0,<8.0.0
 # The Redfish hardware type uses the Sushy library
-sushy>=3.10.0,<4.0.0
+git+https://github.com/sapcc/sushy.git@stable/xena-m3#egg=sushy-oem-idrac
 # Dell EMC iDRAC sushy OEM extension
 git+https://github.com/sapcc/sushy-oem-idrac.git@stable/xena-m3#egg=sushy-oem-idrac
 


### PR DESCRIPTION
We need a fix for Cisco BMCs, as the sessions
are not properly closed otherwise