### PR TITLE
No stable/xena anymore

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -13,7 +13,7 @@ git+https://github.com/sapcc/sushy.git@stable/xena-m3#egg=sushy
 # Dell EMC iDRAC sushy OEM extension
 git+https://github.com/sapcc/sushy-oem-idrac.git@stable/xena-m3#egg=sushy-oem-idrac
 
-git+https://github.com/openstack/ironic-inspector@stable/xena#egg=ironic-inspector
+git+https://github.com/sapcc/ironic-inspector@stable/xena-m3#egg=ironic-inspector
 git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middleware
 git+https://github.com/sapcc/openstack-audit-middleware.git@master#egg=audit-middleware
 git+https://github.com/sapcc/ptftpd.git#egg=ptftpd


### PR DESCRIPTION
It is now unsupported/xena in upstream, or stable/xena-m3 in our repo. The latter fits our pipeline pattern.

Change-Id: Ib7d687630e03350b37d4ff5848325bb77df21934