### PR TITLE
Ironic Upgrade, port relevant changes from 2023.1-m3 to 2025.2-m3

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -1,0 +1,15 @@
+raven
+redis
+
+# ironic driver dep
+python-openstackclient
+python-ilorest-library>=2.1.0
+hpOneView>=4.4.0
+ucsmsdk>=0.9.1
+ImcSdk>=0.7.2
+pymemcache==1.2.9
+
+git+https://github.com/openstack/ironic-inspector@stable/train#egg=ironic-inspector
+git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middleware
+git+https://github.com/sapcc/openstack-audit-middleware.git@master#egg=audit-middleware
+git+https://github.com/sapcc/ptftpd.git#egg=ptftpd

--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -6,11 +6,16 @@ redis
 python-openstackclient
 python-ilorest-library>=2.1.0
 hpOneView>=4.4.0
-ucsmsdk>=0.9.1
-ImcSdk>=0.7.2
-pymemcache==1.2.9
 
-git+https://github.com/openstack/ironic-inspector@stable/train#egg=ironic-inspector
+# The Redfish hardware type uses the Sushy library
+# upstream has fwiesels changes starting from 2024.1
+git+https://github.com/sapcc/sushy.git@stable/2025.2-m3#egg=sushy
+# Dell EMC iDRAC sushy OEM extension
+git+https://github.com/openstack/sushy-oem-idrac.git@master#egg=sushy-oem-idrac
+
+# the inspector is going to get deprecated soon and we never used it
+git+https://github.com/sapcc/ironic-inspector@stable/2025.2#egg=ironic-inspector
 git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middleware
 git+https://github.com/sapcc/openstack-audit-middleware.git@master#egg=audit-middleware
 git+https://github.com/sapcc/ptftpd.git#egg=ptftpd
+-e git+https://github.com/sapcc/python-agentliveness@master#egg=agentliveness

--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -1,4 +1,5 @@
-raven
+jaeger-client
+git+https://github.com/sapcc/sentrylogger.git#egg=sapcc-sentrylogger
 redis
 
 # ironic driver dep

--- a/ironic/api/app.py
+++ b/ironic/api/app.py
@@ -15,8 +15,15 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+
 import keystonemiddleware.audit as audit_middleware
+from ironic_lib import auth_basic
 from keystonemiddleware import auth_token
+# Try using custom ccloud auditmiddleware
+try:
+    import auditmiddleware as audit_middleware
+except ImportError:
+    import keystonemiddleware.audit as audit_middleware
 from oslo_config import cfg
 import oslo_middleware.cors as cors_middleware
 from oslo_middleware import healthcheck

--- a/ironic/api/app.py
+++ b/ironic/api/app.py
@@ -25,6 +25,7 @@ try:
 except ImportError:
     import keystonemiddleware.audit as audit_middleware
 from oslo_config import cfg
+from oslo_utils import importutils
 import oslo_middleware.cors as cors_middleware
 from oslo_middleware import healthcheck
 from oslo_middleware import http_proxy_to_wsgi
@@ -41,6 +42,10 @@ from ironic.api.middleware import request_log
 from ironic.common import auth_basic
 from ironic.common import exception
 from ironic.conf import CONF
+
+# sapcc/openstack-watcher-middleware
+watcher_errors = importutils.try_import('watcher.errors')
+watcher_middleware = importutils.try_import('watcher.watcher')
 
 
 class IronicCORS(cors_middleware.CORS):
@@ -120,6 +125,20 @@ def setup_app(pecan_config=None, extra_hooks=None):
             app,
             auth=auth_middleware,
             public_api_routes=pecan_config.app.acl_public_routes)
+
+        # sapcc/openstack-watcher-middleware
+    if watcher_errors and watcher_middleware and CONF.watcher.enabled:
+        try:
+            app = watcher_middleware.OpenStackWatcherMiddleware(
+                app,
+                config=dict(CONF.watcher)
+            )
+        except (EnvironmentError, OSError,
+                watcher_errors.ConfigError) as e:
+            raise exception.InputFileError(
+                file_name=CONF.watcher.config_file,
+                reason=e
+            )
 
     if CONF.profiler.enabled:
         app = osprofiler_web.WsgiMiddleware(app)

--- a/ironic/common/exception.py
+++ b/ironic/common/exception.py
@@ -641,6 +641,9 @@ class SwiftObjectNotFoundError(SwiftOperationError):
     _msg_fmt = _("Swift object %(obj)s from container %(container)s "
                  "not found. Operation '%(operation)s' failed.")
 
+class SwiftTempUrlKeyNotFoundError(SwiftOperationError):
+    _msg_fmt = _("Swift Temp-Url-Key property not found in account."
+                 " Operation '%(operation)s' failed.")
 
 class SNMPFailure(DriverOperationError):
     _msg_fmt = _("SNMP operation '%(operation)s' failed: %(error)s")

--- a/ironic/common/glance_service/image_service.py
+++ b/ironic/common/glance_service/image_service.py
@@ -354,6 +354,15 @@ class GlanceImageService(object):
 
         image_id = image_info['id']
 
+        if CONF.glance.swift_store_multi_tenant:
+            container_id = "glance_%s" % image_id
+            LOG.debug('Getting temp-url for multi-tenant setup. container: %(container)s and owner: %(owner)s',
+                    {'container': container_id, 'owner': image_info['owner']})
+            object_id = image_id
+            swift_api = swift.SwiftAPI(container_project_id=image_info['owner'])
+            return swift_api.get_temp_url(container=container_id, obj=object_id,
+                                      timeout=CONF.glance.swift_temp_url_duration)
+
         url_fragments = {
             'api_version': CONF.glance.swift_api_version,
             'container': self._get_swift_container(image_id),

--- a/ironic/common/keystone.py
+++ b/ironic/common/keystone.py
@@ -94,6 +94,14 @@ def get_auth(group, **auth_kwargs):
         raise
     return auth
 
+@ks_exceptions
+def get_admin_auth_token(session):
+    """Get admin token.
+    Currently used for inspector, glance and swift clients.
+    Only swift client does not actually support using sessions directly,
+    LP #1518938, others will be updated in ironic code.
+    """
+    return session.get_token()
 
 @ks_exceptions
 def get_adapter(group, **adapter_kwargs):
@@ -108,6 +116,26 @@ def get_adapter(group, **adapter_kwargs):
     """
     return ks_loading.load_adapter_from_conf_options(CONF, group,
                                                      **adapter_kwargs)
+
+# NOTE(pas-ha) Used by neutronclient and resolving ironic API only
+# FIXME(pas-ha) remove this while moving to kesytoneauth adapters
+@ks_exceptions
+def get_service_url(session, **kwargs):
+    """Find endpoint for given service in keystone catalog.
+    If 'interface' is provided, fetches service url of this interface.
+    Otherwise, first tries to fetch 'internal' endpoint,
+    and then the 'public' one.
+    :param session: keystoneauth Session object
+    :param kwargs: any other arguments accepted by Session.get_endpoint method
+    """
+
+    if 'interface' in kwargs:
+        return session.get_endpoint(**kwargs)
+    try:
+        return session.get_endpoint(interface='internal', **kwargs)
+    except kaexception.EndpointNotFound:
+        return session.get_endpoint(interface='public', **kwargs)
+
 
 
 def get_endpoint(group, **adapter_kwargs):

--- a/ironic/common/swift.py
+++ b/ironic/common/swift.py
@@ -14,6 +14,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from base64 import urlsafe_b64encode
+from functools import lru_cache
+from os import urandom
+from http import client as http_client
 from urllib import parse as urlparse
 
 import openstack
@@ -25,27 +29,68 @@ from ironic.common.i18n import _
 from ironic.common import keystone
 from ironic.conf import CONF
 
-LOG = log.getLogger(__name__)
 
-_SWIFT_SESSION = None
-
-
-def get_swift_session():
-    global _SWIFT_SESSION
-    if not _SWIFT_SESSION:
-        auth = keystone.get_auth('swift')
-        _SWIFT_SESSION = keystone.get_session('swift', auth=auth)
-    return _SWIFT_SESSION
+@lru_cache(maxsize=32)
+def get_swift_session(**session_args):
+    auth = keystone.get_auth('swift', **session_args)
+    return keystone.get_session('swift', auth=auth)
 
 
 class SwiftAPI(object):
     """API for communicating with Swift."""
 
-    def __init__(self):
-        """Initialize the connection with swift"""
-        self.connection = openstack.connection.Connection(
-            session=get_swift_session(),
-            oslo_conf=CONF)
+    connection = None
+    """Underlying Swift connection object."""
+
+    def __init__(self, **session_args):
+        """Initialize the connection with swift
+
+        :raises: ConfigInvalid if required keystone authorization credentials
+         with swift are missing.
+        """
+        container_project_id = session_args.pop('container_project_id', None)
+        session = get_swift_session(**session_args)
+        preauthurl = keystone.get_service_url(session,
+                                              service_type='object-store')
+        session_project_id = session.get_project_id()
+
+        if container_project_id and preauthurl.endswith(session_project_id):
+            preauthurl = preauthurl.replace(session_project_id,
+                                            container_project_id)
+        params = {
+            'retries': CONF.swift.swift_max_retries,
+            'preauthurl': preauthurl,
+            'preauthtoken': keystone.get_admin_auth_token(session)
+        }
+        # NOTE(pas-ha) swiftclient still (as of 3.3.0) does not use
+        # (adapter-based) SessionClient, and uses the passed in session
+        # only to resolve endpoint and get a token,
+        # but not to make further requests to Swift itself (LP 1736135).
+        # Thus we need to deconstruct back all the adapter- and
+        # session-related args as loaded by keystoneauth from config
+        # to pass them to the client explicitly.
+        # TODO(pas-ha) re-write this when swiftclient is brought on par
+        # with other OS clients re auth plugins, sessions and adapters
+        # support.
+        # TODO(pas-ha) pass the context here and use token from context
+        # with service auth
+        params['session'] = session = get_swift_session()
+        endpoint = keystone.get_endpoint('swift', session=session)
+        params['os_options'] = {'object_storage_url': endpoint}
+        # deconstruct back session-related options
+        params['timeout'] = session.timeout
+        if session.verify is False:
+            params['insecure'] = True
+        elif isinstance(session.verify, str):
+            params['cacert'] = session.verify
+        if session.cert:
+            # NOTE(pas-ha) although setting cert as path to single file
+            # with both client cert and key is supported by Session,
+            # keystoneauth loading always sets the session.cert
+            # as tuple of cert and key.
+            params['cert'], params['cert_key'] = session.cert
+
+        self.connection = swift_client.Connection(**params)
 
     def create_object(self, container, obj, filename,
                       object_headers=None):
@@ -117,10 +162,10 @@ class SwiftAPI(object):
         :returns: The temp url for the object.
         :raises: SwiftOperationError, if any operation with Swift fails.
         """
-        endpoint = keystone.get_endpoint('swift', session=get_swift_session())
-        parse_result = urlparse.urlparse(endpoint)
+        temp_url_key = self._get_temp_url_key()
+
+        parse_result = urlparse.urlparse(self.connection.url)
         swift_object_path = '/'.join((parse_result.path, container, obj))
-        temp_url_key = self.get_temp_url_key()
         if not temp_url_key:
             raise exception.MissingParameterValue(_(
                 'Swift temporary URLs require a shared secret to be '
@@ -132,10 +177,26 @@ class SwiftAPI(object):
             (parse_result.scheme, parse_result.netloc, url_path,
              None, None, None))
 
-    def generate_temp_url(self, path, timeout, method, temp_url_key):
-        """Returns the temp url for a given path"""
-        return self.connection.object_store.generate_temp_url(
-            path, timeout, method, temp_url_key=temp_url_key)
+    def _get_temp_url_key(self):
+        try:
+            account_info = self.connection.head_account()
+        except swift_exceptions.ClientException as e:
+            operation = _("head account")
+            raise exception.SwiftOperationError(operation=operation,
+                                                error=e)
+
+        temp_url_key = account_info.get('x-account-meta-temp-url-key', None)
+
+        if temp_url_key:
+            return temp_url_key
+
+        if CONF.swift.swift_set_temp_url_key:
+            temp_url_key = urlsafe_b64encode(urandom(30))
+            self.connection.post_account(headers={'x-account-meta-temp-url-key': temp_url_key})
+            return temp_url_key
+
+        operation = _("get temp-url-key")
+        raise exception.SwiftTempUrlKeyNotFoundError(operation=operation)
 
     def get_object(self, object, container):
         """Downloads a given object from Swift.

--- a/ironic/conf/__init__.py
+++ b/ironic/conf/__init__.py
@@ -54,6 +54,7 @@ from ironic.conf import service_catalog
 from ironic.conf import snmp
 from ironic.conf import swift
 from ironic.conf import vnc
+from ironic.conf import watcher
 
 CONF = cfg.CONF
 
@@ -96,3 +97,4 @@ service_catalog.register_opts(CONF)
 snmp.register_opts(CONF)
 swift.register_opts(CONF)
 vnc.register_opts(CONF)
+watcher.register_opts(CONF)

--- a/ironic/conf/agent.py
+++ b/ironic/conf/agent.py
@@ -83,6 +83,21 @@ opts = [
                help=_('The path to the directory where the logs should be '
                       'stored, used when the deploy_logs_storage_backend '
                       'is configured to "local".')),
+    cfg.StrOpt('deploy_logs_swift_project_id',
+                default=None,
+                help=_('The project id the log container is stored in.'
+                       'Used when the deploy_logs_storage_backend is '
+                       'configured to "swift".')),
+     cfg.StrOpt('deploy_logs_swift_project_domain_name',
+                default=None,
+                help=_('The project domain name the log container is stored in.'
+                       'Used when the deploy_logs_storage_backend is '
+                       'configured to "swift".')),
+     cfg.StrOpt('deploy_logs_swift_project_name',
+                default=None,
+                help=_('The project name the log container is stored in.'
+                       'Used when the deploy_logs_storage_backend is '
+                       'configured to "swift".')),
     cfg.StrOpt('deploy_logs_swift_container',
                default='ironic_deploy_logs_container',
                mutable=True,

--- a/ironic/conf/audit.py
+++ b/ironic/conf/audit.py
@@ -32,6 +32,16 @@ opts = [
                       'auditing will not be done on any GET or POST '
                       'requests if this is set to "GET,POST". It is used '
                       'only when API audit is enabled.')),
+
+    cfg.BoolOpt('record_payloads', default=False,
+                help=_('The payload of the API response to a CRUD request can be '
+                       'attached to the event optionally. This will increase the '
+                       'size of the events, but brings a lot of value when it '
+                       'comes to diagnostics')),
+
+    cfg.BoolOpt('metrics_enabled', default=False,
+                help=_('The middleware can emit statistics on emitted events '
+                       'using tagged statsd metrics.')),
 ]
 
 

--- a/ironic/conf/console.py
+++ b/ironic/conf/console.py
@@ -13,7 +13,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
+import os
 from oslo_config import cfg
 
 from ironic.common.i18n import _
@@ -60,6 +60,30 @@ opts = [
                       'proxy service running on the host of ironic '
                       'conductor, in the form of <start>:<stop>. This option '
                       'is used by both Shellinabox and Socat console')),
+    cfg.IntOpt('socket_gid',
+               default=os.getgid(),
+               help=_('The group id of a potentially created socket')),
+    cfg.StrOpt('socket_permission',
+               default='0500',
+               help=_('Permissions of created unix sockets (octal)')),
+    cfg.StrOpt('terminal_url_scheme',
+               default='%(scheme)s://%(host)s:%(port)s',
+               help=_('Url to the proxy')),
+    cfg.StrOpt('ssh_command_pattern',
+               default='sshpass -f %(pw_file)s ssh -l %(username)s %(address)s',
+               help=_('Command pattern to establish a ssh connection')),
+    cfg.StrOpt('url_auth_digest_secret',
+               default='',
+               help=_('Secret to hash the authentication token with')),
+    cfg.StrOpt('url_auth_digest_algorithm',
+               default='md5:base64',
+               help=_('The digest algorithm (any python hash, followed by either :base64, or :hex')),
+    cfg.IntOpt('url_auth_digest_expiry',
+               default=900,
+               help=_('The validity of the token in seconds')),
+    cfg.StrOpt('url_auth_digest_pattern',
+               default='%(expiry)s%(uuid)s %(secret)s',
+               help=_('Python string formatting pattern, with expiry, uuid, and secret')),
 ]
 
 

--- a/ironic/conf/glance.py
+++ b/ironic/conf/glance.py
@@ -92,6 +92,13 @@ opts = [
                'section). Swift temporary URL format: '
                '"endpoint_url/api_version/account/container/object_id"')),
     cfg.StrOpt(
+        'swift_store_multi_tenant',
+        help=_('If glance uses a multi-tenant store, and stores the images '
+               'in each owners swift account. '
+               'This makes the options "swift_account" and "swift_temp_url_key" '
+               'obsolete'
+               )),
+    cfg.StrOpt(
         'swift_account_prefix',
         default='AUTH',
         help=_('The prefix added to the project uuid to determine the swift '

--- a/ironic/conf/swift.py
+++ b/ironic/conf/swift.py
@@ -15,6 +15,18 @@
 #    under the License.
 
 from ironic.conf import auth
+from oslo_config import cfg
+from ironic.common.i18n import _
+
+opts = [
+    cfg.IntOpt('swift_max_retries',
+               default=2,
+               help=_('Maximum number of times to retry a Swift request, '
+                      'before failing.')),
+    cfg.BoolOpt('swift_set_temp_url_key',
+                default=False,
+                help=_('Should the service try to set the temp-url key if missing '))
+]
 
 
 def register_opts(conf):

--- a/ironic/conf/watcher.py
+++ b/ironic/conf/watcher.py
@@ -1,0 +1,61 @@
+# Copyright 2016 Intel Corporation
+# Copyright 2014 OpenStack Foundation
+# All Rights Reserved
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_config import cfg
+
+from ironic.common.i18n import _
+
+opts = [
+    cfg.BoolOpt('enabled',
+                default=False,
+                help=_('Enable the openstack-watcher-middleware')),
+    cfg.StrOpt('service_type',
+               default='baremetal',
+               help=_('The type of the service')),
+    cfg.StrOpt('cadf_service_name',
+               default='service/compute/baremetal',
+               help=_('The name of the service according to CADF')),
+    cfg.StrOpt('config_file',
+               help=_('Path to configuration file')),
+    cfg.StrOpt('statsd_host',
+               default='127.0.0.1',
+               help=_('Host of the StatsD backend')),
+    cfg.StrOpt('statsd_namespace',
+               default='openstack_watcher',
+               help=_('Namespace to use for metrics')),
+    cfg.IntOpt('statsd_port',
+               default=9125,
+               help=_('Port of the StatsD backend')),
+    cfg.BoolOpt('target_project_id_from_path',
+                default=False,
+                help=_('Whether to get the target project uid from the path')),
+    cfg.BoolOpt('target_project_id_from_service_catalog',
+                default=False,
+                help=_('Whether to get the target project uid from the service catalog')),
+    cfg.BoolOpt('include_target_project_id_in_metric',
+                default=True,
+                help=_('Whether to include the target project id in the metrics')),
+    cfg.BoolOpt('include_target_domain_id_in_metric',
+                default=True,
+                help=_('Whether to include the target domain id in the metrics')),
+    cfg.BoolOpt('include_authentication_initiator_user_id_in_metric',
+                default=True,
+                help=_('Whether to include the initiator user id for authentication request in the metrics'))
+]
+
+
+def register_opts(conf):
+    conf.register_opts(opts, group='watcher')

--- a/ironic/drivers/drac.py
+++ b/ironic/drivers/drac.py
@@ -59,7 +59,8 @@ class IDRACHardware(redfish.RedfishHardware):
     def supported_console_interfaces(self):
         """List of supported console interfaces."""
         return [ipmitool.IPMISocatConsole, ipmitool.IPMIShellinaboxConsole,
-                noop.NoConsole, console.DracRedFishVNCConsole]
+                noop.NoConsole, console.DracRedFishVNCConsole,
+                console.DracRedFishKVMConsole]
 
     @property
     def supported_management_interfaces(self):

--- a/ironic/drivers/drac.py
+++ b/ironic/drivers/drac.py
@@ -19,15 +19,23 @@ from oslo_config import cfg
 
 from ironic.drivers.modules.drac import bios
 from ironic.drivers.modules.drac import boot
+from ironic.drivers.modules.drac import console
 from ironic.drivers.modules.drac import inspect as drac_inspect
 from ironic.drivers.modules.drac import management
 from ironic.drivers.modules.drac import power
 from ironic.drivers.modules.drac import raid
 from ironic.drivers.modules.drac import vendor_passthru
+
 from ironic.drivers.modules.redfish import boot as redfish_boot
 from ironic.drivers.modules.redfish import inspect as redfish_inspect
 from ironic.drivers.modules.redfish import raid as redfish_raid
 from ironic.drivers import redfish
+
+from ironic.drivers.modules import ipmitool
+from ironic.drivers.modules import ipxe
+from ironic.drivers.modules import noop
+from ironic.drivers.modules import pxe
+
 
 
 CONF = cfg.CONF
@@ -46,6 +54,12 @@ class IDRACHardware(redfish.RedfishHardware):
         idx = inherited.index(redfish_boot.RedfishVirtualMediaBoot)
         inherited[idx] = boot.DracRedfishVirtualMediaBoot
         return inherited
+
+    @property
+    def supported_console_interfaces(self):
+        """List of supported console interfaces."""
+        return [ipmitool.IPMISocatConsole, ipmitool.IPMIShellinaboxConsole,
+                noop.NoConsole, console.DracRedFishVNCConsole]
 
     @property
     def supported_management_interfaces(self):

--- a/ironic/drivers/modules/console_utils.py
+++ b/ironic/drivers/modules/console_utils.py
@@ -244,7 +244,7 @@ def get_shellinabox_console_url(port, uuid=None):
                 'uuid': uuid,
                 'expiry': expiry,
                 'secret': CONF.console.url_auth_digest_secret }
-            h.update(to_sign)
+            h.update(to_sign.encode('utf-8'))
             if digest_algorithm == 'base64':
                 digest = urlsafe_b64encode(h.digest())
             else:
@@ -258,7 +258,7 @@ def get_shellinabox_console_url(port, uuid=None):
                                                'host': console_host,
                                                'port': port,
                                                'uuid': uuid,
-                                               'digest': digest,
+                                               'digest': digest.decode("utf-8"),
                                                'expiry': expiry }
 
 

--- a/ironic/drivers/modules/console_utils.py
+++ b/ironic/drivers/modules/console_utils.py
@@ -20,6 +20,7 @@ Ironic console utilities.
 """
 
 import errno
+import hashlib
 import fcntl
 import ipaddress
 import os
@@ -28,6 +29,9 @@ import socket
 import subprocess
 import time
 
+from base64 import urlsafe_b64encode
+from datetime import datetime, timedelta
+from ironic_lib import utils as ironic_utils
 from oslo_concurrency import lockutils
 from oslo_log import log as logging
 from oslo_service import loopingcall
@@ -70,6 +74,15 @@ def _ensure_console_pid_dir_exists():
                      " Reason: %(reason)s.") % {'path': dir, 'reason': exc})
             LOG.error(msg)
             raise exception.ConsoleError(message=msg)
+
+
+def _get_console_unix_socket(node_uuid):
+    """Generate the unix socket file name."""
+
+    pid_dir = _get_console_pid_dir()
+    name = "%s.sock" % node_uuid
+    path = os.path.join(pid_dir, name)
+    return path
 
 
 def _get_console_pid_file(node_uuid):
@@ -214,17 +227,39 @@ def release_port(port):
     ALLOCATED_PORTS.discard(port)
 
 
-def get_shellinabox_console_url(port):
+def get_shellinabox_console_url(port, uuid=None):
     """Get a url to access the console via shellinaboxd.
 
     :param port: the terminal port for the node.
     """
 
+    digest = None
+    expiry = None
+    if CONF.console.url_auth_digest_secret:
+        try:
+            hash_algorithm, digest_algorithm = CONF.console.url_auth_digest_algorithm.split(':', 1)
+            h = hashlib.new(hash_algorithm)
+            expiry = int((datetime.utcnow() - datetime(1970,1,1) + timedelta(seconds=CONF.console.url_auth_digest_expiry)).total_seconds())
+            to_sign = CONF.console.url_auth_digest_pattern % {
+                'uuid': uuid,
+                'expiry': expiry,
+                'secret': CONF.console.url_auth_digest_secret }
+            h.update(to_sign)
+            if digest_algorithm == 'base64':
+                digest = urlsafe_b64encode(h.digest())
+            else:
+                digest = h.hexdigest()
+        except ValueError as e:
+            LOG.warning("Could not setup authenticated url due to %s", e)
+
     console_host = utils.wrap_ipv6(CONF.my_ip)
     scheme = 'https' if CONF.console.terminal_cert_dir else 'http'
-    return '%(scheme)s://%(host)s:%(port)s' % {'scheme': scheme,
+    return CONF.console.terminal_url_scheme % {'scheme': scheme,
                                                'host': console_host,
-                                               'port': port}
+                                               'port': port,
+                                               'uuid': uuid,
+                                               'digest': digest,
+                                               'expiry': expiry }
 
 
 class _PopenNonblockingPipe(object):
@@ -291,8 +326,17 @@ def start_shellinabox_console(node_uuid, port, console_cmd):
         args.append(CONF.console.terminal_cert_dir)
     else:
         args.append("-t")
-    args.append("-p")
-    args.append(str(port))
+    if port == 'unix' or port is None:
+        args.append('--unixdomain-only')
+        args.append(('%(path)s:%(uid)s:%(gid)s:%(mode)s' % {
+            'path': _get_console_unix_socket(node_uuid),
+            'uid': os.getuid(),
+            'gid': CONF.console.socket_gid,
+            'mode': CONF.console.socket_permission }))
+    else:
+        args.append("-p")
+        args.append(str(port))
+
     args.append("--background=%s" % pid_file)
     args.append("-s")
     args.append(console_cmd)

--- a/ironic/drivers/modules/drac/console.py
+++ b/ironic/drivers/modules/drac/console.py
@@ -1,0 +1,136 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+Console functionality
+"""
+
+import secrets
+from urllib import parse as urlparse
+
+from oslo_log import log
+from oslo_utils import importutils
+
+from ironic.common import exception
+from ironic.drivers import base
+from ironic.drivers.modules.redfish import utils as redfish_utils
+
+LOG = log.getLogger(__name__)
+
+sushy = importutils.try_import('sushy')
+sushy_oem_idrac = importutils.try_import('sushy_oem_idrac')
+
+_ENABLED = "Enabled"
+_DISABLED = "Disabled"
+_VNC_ENABLE_ATTRIBUTE = "VNCServer.1.Enable"
+_VNC_PORT_ATTRIBUTE = "VNCServer.1.Port"
+_VNC_PASSWORD_ATTRIBUTE = "VNCServer.1.Password"
+
+
+class DracRedFishVNCConsole(base.ConsoleInterface):
+    def __init__(self):
+        """Initialize the Drac Redfish console interface.
+
+        :raises: DriverLoadError if the driver can't be loaded due to
+            missing dependencies
+        """
+        super(DracRedFishVNCConsole, self).__init__()
+        if not sushy:
+            raise exception.DriverLoadError(
+                driver='drac',
+                reason=_('Unable to import the sushy library'))
+
+
+    def get_properties(self):
+        """Return the properties of the interface.
+
+        :returns: dictionary of <property name>:<property description> entries.
+        """
+        return redfish_utils.COMMON_PROPERTIES.copy()
+
+    def validate(self, task):
+        """Validates the driver information needed by the redfish driver.
+
+        :param task: a TaskManager instance containing the node to act on.
+        :raises: InvalidParameterValue on malformed parameter(s)
+        :raises: MissingParameterValue on missing parameter(s)
+        """
+        redfish_utils.parse_driver_info(task.node)
+
+    def start_console(self, task):
+        """Start a remote console for the task's node.
+
+        This method should not raise an exception if console already started.
+
+        :param task: A TaskManager instance containing the node to act on.
+        """
+        attributes = self._get_idrac_attributes(task)
+        password = secrets.token_hex(4)
+        attributes.set_attributes({
+            _VNC_ENABLE_ATTRIBUTE: _ENABLED,
+            _VNC_PASSWORD_ATTRIBUTE: password,
+        })
+        node = task.node
+        driver_internal_info = node.driver_internal_info
+        driver_internal_info["vnc_password"] = password
+        node.driver_internal_info = driver_internal_info
+        node.save()
+
+    def stop_console(self, task):
+        """Stop the remote console session for the task's node.
+
+        :param task: A TaskManager instance containing the node to act on.
+        """
+        attributes = self._get_idrac_attributes(task)
+        if attributes.attributes[_VNC_ENABLE_ATTRIBUTE] != _DISABLED:
+            attributes.set_attributes({
+                _VNC_ENABLE_ATTRIBUTE: _DISABLED
+            })
+        node = task.node
+        driver_internal_info = node.driver_internal_info
+        password = driver_internal_info.pop("vnc_password", None)
+        if password:
+            node.driver_internal_info = driver_internal_info
+            node.save()
+
+    def get_console(self, task):
+        """Get connection information about the console.
+
+        This method should return the necessary information for the
+        client to access the console.
+
+        :param task: A TaskManager instance containing the node to act on.
+        :returns: the console connection information.
+        """
+        attributes = self._get_idrac_attributes(task)
+        port = attributes.attributes[_VNC_PORT_ATTRIBUTE]
+
+        driver_info = task.node.driver_info
+        address = driver_info['redfish_address']
+        parsed = urlparse.urlparse(address)
+
+        node = task.node
+        driver_internal_info = node.driver_internal_info
+        password = driver_internal_info["vnc_password"]
+
+        return {'type': 'vnc',
+                'url': f"vnc://:{password}@{parsed.hostname}:{port}"}
+
+    @staticmethod
+    def _get_idrac_attributes(task):
+        manager = redfish_utils.get_manager(task.node)
+        oem_manager = manager.get_oem_extension('Dell')
+        for attributes in oem_manager.attributes:
+            if attributes.identity == "iDRACAttributes":
+                return attributes
+        return None

--- a/ironic/drivers/modules/ipmitool.py
+++ b/ironic/drivers/modules/ipmitool.py
@@ -1637,8 +1637,8 @@ class IPMIShellinaboxConsole(IPMIConsole):
         # duplicated port.
         _release_allocated_port(task)
         driver_info = _parse_driver_info(task.node)
-        if not driver_info['port']:
-            driver_info['port'] = _allocate_port(task)
+        # if not driver_info['port']:
+        #    driver_info['port'] = _allocate_port(task)
 
         try:
             self._exec_stop_console(driver_info)
@@ -1679,7 +1679,9 @@ class IPMIShellinaboxConsole(IPMIConsole):
             # OSError is raised when sol session is already deactivated,
             # so we can ignore it.
             pass
-        url = console_utils.get_shellinabox_console_url(driver_info['port'])
+
+        url = console_utils.get_shellinabox_console_url(
+            port=driver_info['port'], uuid=task.node.uuid)
         return {'type': 'shellinabox', 'url': url}
 
 

--- a/ironic/drivers/modules/ipmitool.py
+++ b/ironic/drivers/modules/ipmitool.py
@@ -1555,10 +1555,6 @@ class IPMIConsole(base.ConsoleInterface):
 
         """
         driver_info = _parse_driver_info(task.node)
-        if not driver_info['port'] and CONF.console.port_range is None:
-            raise exception.MissingParameterValue(_(
-                "Either missing 'ipmi_terminal_port' parameter in node's "
-                "driver_info or [console]port_range is not configured"))
 
         if driver_info['protocol_version'] != '2.0':
             raise exception.InvalidParameterValue(_(

--- a/ironic/drivers/modules/redfish/boot.py
+++ b/ironic/drivers/modules/redfish/boot.py
@@ -169,37 +169,6 @@ def _test_retry(exception):
         return True
     return False
 
-
-def _has_vmedia_via_systems(system):
-    """Indicates if virtual media is available through Systems
-
-    :param system: A redfish System object
-    :return: True if the System has virtual media, else False
-    """
-    try:
-        system.virtual_media
-        return True
-    except sushy.exceptions.MissingAttributeError:
-        return False
-    except AttributeError:
-        # NOTE(wncslln): In case of older versions of sushy are
-        # used.
-        return False
-
-
-def _has_vmedia_via_manager(manager):
-    """Indicates if virtual media is available in the Manager
-
-    :param manager: A redfish System object
-    :return: True if the System has virtual media, else False
-    """
-    try:
-        manager.virtual_media
-        return True
-    except sushy.exceptions.MissingAttributeError:
-        return False
-
-
 def _get_vmedia(task, managers):
     """GET virtual media details
 
@@ -249,6 +218,35 @@ def _get_vmedia(task, managers):
     else:
         exc_msg = 'No suitable virtual media device found'
     raise exception.InvalidParameterValue(exc_msg)
+
+
+def _has_vmedia_via_systems(system):
+    """Indicates if virtual media is available through Systems
+
+    :param system: A redfish System object
+    :return: True if the System has virtual media, else False
+    """
+    try:
+        system.virtual_media
+        return True
+    except sushy.exceptions.MissingAttributeError:
+        return False
+    except AttributeError:
+        # NOTE(wncslln): In case of older versions of sushy are
+        # used.
+        return False
+    
+def _has_vmedia_via_manager(manager):
+    """Indicates if virtual media is available in the Manager
+
+    :param manager: A redfish System object
+    :return: True if the System has virtual media, else False
+    """
+    try:
+        manager.virtual_media
+        return True
+    except sushy.exceptions.MissingAttributeError:
+        return False
 
 
 def _insert_vmedia(task, managers, boot_url, boot_device):
@@ -352,9 +350,7 @@ def _insert_vmedia_in_resource(task, resource, boot_url, boot_device,
                                        'boot_url': boot_url,
                                        'boot_device': boot_device})
                 return True
-
-            continue
-
+            continue        
         try:
             v_media.insert_media(boot_url, inserted=True,
                                  write_protected=True)

--- a/ironic/drivers/modules/redfish/utils.py
+++ b/ironic/drivers/modules/redfish/utils.py
@@ -54,6 +54,16 @@ OPTIONAL_PROPERTIES = {
                            'manages more than one ComputerSystem. Otherwise '
                            'ironic will pick the only available '
                            'ComputerSystem automatically.'),
+    'redfish_manager_id': _('The canonical path to the Manager '
+                           'resource that the driver will interact with. '
+                           'It should include the root service, version and '
+                           'the unique resource path to a Manager '
+                           'within the same authority as the redfish_address '
+                           'property. For example: /redfish/v1/Managers/1. '
+                           'This property is only required if target BMC '
+                           'consists of more than one manager. Otherwise '
+                           'ironic will pick the only available '
+                           'ComputerSystem automatically.'),
     'redfish_username': _('User account with admin/server-profile access '
                           'privilege. Although this property is not '
                           'mandatory it\'s highly recommended to set a '
@@ -160,6 +170,20 @@ def parse_driver_info(node):
                   '/redfish/v1/Systems/1') %
                 {'value': driver_info['redfish_system_id'], 'node': node.uuid})
 
+    redfish_manager_id = driver_info.get('redfish_manager_id')
+    if redfish_manager_id is not None:
+        try:
+            redfish_manager_id = urlparse.quote(redfish_manager_id)
+        except (TypeError, AttributeError):
+            raise exception.InvalidParameterValue(
+                _('Invalid value "%(value)s" set in '
+                  'driver_info/redfish_manager_id on node %(node)s. '
+                  'The value should be a path (string) to the resource '
+                  'that the driver will interact with. For example: '
+                  '/redfish/v1/Managers/1') %
+                {'value': driver_info['redfish_manager_id'],
+                 'node': node.uuid})
+
     # Check if verify_ca is a Boolean or a file/directory in the file-system
     verify_ca = driver_utils.get_verify_ca(
         node, driver_info.get('redfish_verify_ca', True))
@@ -196,6 +220,7 @@ def parse_driver_info(node):
 
     sushy_params = {'address': address,
                     'system_id': redfish_system_id,
+                    'manager_id': redfish_manager_id,
                     'username': driver_info.get('redfish_username'),
                     'password': driver_info.get('redfish_password'),
                     'verify_ca': verify_ca,
@@ -377,6 +402,30 @@ def get_system(node):
         LOG.error('The Redfish System "%(system)s" was not found for '
                   'node %(node)s. Error %(error)s',
                   {'system': system_id or '<default>',
+                   'node': node.uuid, 'error': e})
+        raise exception.RedfishError(error=e)
+
+
+
+def get_manager(node):
+    """Get a Redfish Manager that manages a node.
+
+    :param node: an Ironic node object
+    :raises: RedfishConnectionError when it fails to connect to Redfish
+    :raises: RedfishError if the System is not registered in Redfish
+    """
+    driver_info = parse_driver_info(node)
+    manager_id = driver_info['manager_id']
+
+    try:
+        return _get_connection(
+            node,
+            lambda conn, manager_id: conn.get_manager(manager_id),
+            manager_id)
+    except sushy.exceptions.ResourceNotFoundError as e:
+        LOG.error('The Redfish Manager "%(manager)s" was not found for '
+                  'node %(node)s. Error %(error)s',
+                  {'manager': manager_id or '<default>',
                    'node': node.uuid, 'error': e})
         raise exception.RedfishError(error=e)
 

--- a/ironic/drivers/utils.py
+++ b/ironic/drivers/utils.py
@@ -347,7 +347,15 @@ def store_ramdisk_logs(node, logs, label=None):
             # convert days to seconds
             timeout = CONF.agent.deploy_logs_swift_days_to_expire * 86400
             object_headers = {'X-Delete-After': str(timeout)}
-            swift_api = swift.SwiftAPI()
+            
+            scope = {}
+            if CONF.agent.deploy_logs_swift_project_id:
+                scope['project_id'] = CONF.agent.deploy_logs_swift_project_id
+            elif CONF.agent.deploy_logs_swift_project_name and CONF.agent.deploy_logs_swift_project_domain_name:
+                scope['project_name'] = CONF.agent.deploy_logs_swift_project_name
+                scope['project_domain_name'] = CONF.agent.deploy_logs_swift_project_domain_name
+
+            swift_api = swift.SwiftAPI(**scope)
             swift_api.create_object(
                 CONF.agent.deploy_logs_swift_container, logs_file_name,
                 f.name, object_headers=object_headers)

--- a/ironic/pxe/tftpmap.py
+++ b/ironic/pxe/tftpmap.py
@@ -1,0 +1,15 @@
+import re, os, stat
+
+patterns = [ (re.compile(a), b) for a, b in [
+    (r'^(/tftpboot/)', r'/tftpboot/'),
+    (r'^/tftpboot/', r'/tftpboot/'),
+    (r'^(^/)', r'/tftpboot/\1'),
+    (r'^([^/])', r'/tftpboot/\1')
+]]
+
+# filename -> (stream, size)
+def handle(self, filename):
+    for pattern, replacement in patterns:
+        if pattern.search(filename):
+            new_filename = pattern.sub(replacement, filename)
+            return open(new_filename, 'rb'), os.stat(new_filename)[stat.ST_SIZE]

--- a/ironic/tests/unit/common/test_pxe_utils.py
+++ b/ironic/tests/unit/common/test_pxe_utils.py
@@ -166,6 +166,7 @@ class TestPXEUtils(db_base.DbTestCase):
 
         self.assertEqual(str(expected_template), rendered_template)
 
+
     def test_pxe_config(self):
         rendered_template = utils.render_template(
             CONF.pxe.uefi_pxe_config_template,

--- a/ironic/tests/unit/drivers/modules/redfish/test_boot.py
+++ b/ironic/tests/unit/drivers/modules/redfish/test_boot.py
@@ -1738,7 +1738,8 @@ class RedfishVirtualMediaBootTestCase(db_base.DbTestCase):
             redfish_boot._has_vmedia_device(
                 [mock_manager], sushy.VIRTUAL_MEDIA_FLOPPY, inserted=True))
 
-
+@mock.patch('oslo_utils.eventletutils.EventletEvent.wait',
+            lambda *args, **kwargs: None)
 class RedfishHTTPBootTestCase(db_base.DbTestCase):
 
     def setUp(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,7 @@ ironic.hardware.interfaces.boot =
 ironic.hardware.interfaces.console =
     fake = ironic.drivers.modules.fake:FakeConsole
     fake-graphical = ironic.drivers.modules.fake:FakeGraphicalConsole
+    idrac-redfish-vnc = ironic.drivers.modules.drac.console:DracRedFishVNCConsole
     ilo = ironic.drivers.modules.ilo.console:IloConsoleInterface
     ipmitool-shellinabox = ironic.drivers.modules.ipmitool:IPMIShellinaboxConsole
     ipmitool-socat = ironic.drivers.modules.ipmitool:IPMISocatConsole

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,7 @@ ironic.hardware.interfaces.console =
     fake = ironic.drivers.modules.fake:FakeConsole
     fake-graphical = ironic.drivers.modules.fake:FakeGraphicalConsole
     idrac-redfish-vnc = ironic.drivers.modules.drac.console:DracRedFishVNCConsole
+    idrac-redfish-kvm = ironic.drivers.modules.drac.console:DracRedFishKVMConsole
     ilo = ironic.drivers.modules.ilo.console:IloConsoleInterface
     ipmitool-shellinabox = ironic.drivers.modules.ipmitool:IPMIShellinaboxConsole
     ipmitool-socat = ironic.drivers.modules.ipmitool:IPMISocatConsole


### PR DESCRIPTION
I’ve compared our stable/2023.1-m3 branch against upstream/2023.1 and cherry-picked all relevant commits to port-changes-2023.1-to-2025.2-clean.

Below is the commit list, including both cherry-picked commits and the ones we did not cherry-pick, along with the reasoning:

- [ ] [11a786ac8 (origin/stable/2023.1-m3, stable/2023.1-m3) Merge pull request #46 from sapcc/switch-raven-to-sentrylogger ](https://github.com/sapcc/ironic/commit/11a786ac8)
  -> Merge commit, not cherry-picked

- [x] [586136777 (origin/switch-raven-to-sentrylogger, switch-raven-to-sentrylogger) Replace raven with sapcc-sentrylogger in custom-requirements.txt](https://github.com/sapcc/ironic/commit/586136777)

- [ ] [6b165488f Merge pull request #45 from sapcc/switch-inspector](https://github.com/sapcc/ironic/commit/6b165488f)
  -> Merge commit, not cherry-picked

- [ ] [7b702afbe (origin/switch-inspector) Switch to our inspector fork](https://github.com/sapcc/ironic/commit/7b702afbe)

- [ ] [d0ca79659 Merge pull request #42 from sapcc/superdome-support](https://github.com/sapcc/ironic/commit/d0ca79659)
  -> Merge commit, not cherry-picked

- [ ] [5fe418401 Removing unnecessary packages](https://github.com/sapcc/ironic/commit/5fe418401)
  -> Excluded: only changes packages' versions in requirements.txt, which we want to keep aligned with upstream

- [ ] [a4a5eb637 Merge pull request #41 from sapcc/superdome-support](https://github.com/sapcc/ironic/commit/a4a5eb637)
  -> Merge commit, not cherry-picked

- [ ] [1608aade7 Removed sushy constraint](https://github.com/sapcc/ironic/commit/1608aade7)
  -> Excluded: only changes packages' versions in requirements.txt, which we want to keep aligned with upstream

- [ ] [363f51187 Merge pull request #40 from sapcc/superdome-support](https://github.com/sapcc/ironic/commit/363f51187)
 -> Merge commit, not cherry-picked

- [ ] [d2786df0e Revert "Update sushy dependency to stable/2025.1-m3 to fix version conflict with ironic 8.1.0.dev5713"](https://github.com/sapcc/ironic/commit/d2786df0e)
  -> Revert commit only, not cherry-picked

- [ ] [37966cfec (stable/2025.1-m3) Merge pull request #39 from sapcc/superdome-support](https://github.com/sapcc/ironic/commit/37966cfec)
  -> Merge commit, not cherry-picked

- [ ] [1644efb9e Update sushy dependency to stable/2025.1-m3 to fix version conflict with ironic 8.1.0.dev5713](https://github.com/sapcc/ironic/commit/1644efb9e)
  -> Commit later reverted, not cherry-picked

- [ ] [857f10755 Merge pull request #38 from sapcc/superdome-support](https://github.com/sapcc/ironic/commit/857f10755)
  -> Merge commit, not cherry-picked

- [x] [bb21aa770 Fix spelling reported by codespell](https://github.com/sapcc/ironic/commit/bb21aa770)

- [x] [2ba35145c Allow usage of virtual media via System](https://github.com/sapcc/ironic/commit/2ba35145c)

- [ ] [a5bc32d78 Merge pull request #36 from sapcc/fix-grub-template](https://github.com/sapcc/ironic/commit/a5bc32d78)
  -> Merge commit, not cherry-picked

- [x] [8fe5aadbb (origin/fix-grub-template) Use linux instead of linuxefi in grub config](https://github.com/sapcc/ironic/commit/8fe5aadbb)

- [ ] [7c63ab1b5 Merge pull request #35 from openstack/unmaintained/2023.1](https://github.com/sapcc/ironic/commit/7c63ab1b5)
  -> Merge commit, not cherry-picked

- [ ] [e488ccbd6 Merge pull request #34 from sapcc/fix-custom-requirements](https://github.com/sapcc/ironic/commit/e488ccbd6)
  -> Merge commit, not cherry-picked

- [ ] [fab5d3e33 ironic was set to unmaintained upstream](https://github.com/sapcc/ironic/commit/fab5d3e33)

- [ ] [6e9ce912c Revert "SAP Extension: Install vsmp after the OS"](https://github.com/sapcc/ironic/commit/6e9ce912c)
  -> Revert commit only, not cherry-picked

- [ ] [00a3a1234 Merge pull request #30 from openstack/stable/2023.1](https://github.com/sapcc/ironic/commit/00a3a1234)
  -> Merge commit, not cherry-picked

- [x] [47f43694c [ccloud] fixes console_url encoding](https://github.com/sapcc/ironic/commit/47f43694c)


- [x] [8e56539e2 Config option for Glance Swift Multi-Tentant storage](https://github.com/sapcc/ironic/commit/8e56539e2)


- [ ] [f491cbfdd Update custom requirements to 2023.1](https://github.com/sapcc/ironic/commit/f491cbfdd)


- [ ] [882a6cae6 Fixup sushy egg annotation](https://github.com/sapcc/ironic/commit/882a6cae6)


- [ ] [c095ae174 Use xena-m3 branch for sushy](https://github.com/sapcc/ironic/commit/c095ae174)


- [x] [a50df2b6d Add Drac KVM console](https://github.com/sapcc/ironic/commit/a50df2b6d)


- [x] [2b8f59c8a VNC console for iDRAC via RedFish](https://github.com/sapcc/ironic/commit/2b8f59c8a)


- [ ] [75c3696a0 Add Sushy and draclient for iDrac](https://github.com/sapcc/ironic/commit/75c3696a0)


- [ ] [41f56250c SAP Extension: Install vsmp after the OS](https://github.com/sapcc/ironic/commit/41f56250c)
  -> Commit later reverted, not cherry-picked

- [x] [afb9b003a [ccloud] adds ccloud openstack watcher](https://github.com/sapcc/ironic/commit/afb9b003a)


- [ ] [b8cb8a965 Add jaeger client](https://github.com/sapcc/ironic/commit/b8cb8a965)


- [x] [cfea00aee [ccloud] removes allocating port for IPMIShellinaboxConsole](https://github.com/sapcc/ironic/commit/cfea00aee)


- [ ] [0eb17ac3d [ccloud] adds agentliveness lib](https://github.com/sapcc/ironic/commit/0eb17ac3d)


- [x] [fc69f3424 work on ironic console](https://github.com/sapcc/ironic/commit/fc69f3424)


- [ ] [2d3c82d7f [ccloud] updates custom requirements](https://github.com/sapcc/ironic/commit/2d3c82d7f)


- [ ] [5b6e697a8 [ccloud] removes ucsmsdk dependency](https://github.com/sapcc/ironic/commit/5b6e697a8)


- [x] [b8f287932 [ccloud] adds tftpmap for pxe](https://github.com/sapcc/ironic/commit/b8f287932)


- [x] [f9cf61d7b [ccloud] add support for ccloud audit middleware](https://github.com/sapcc/ironic/commit/f9cf61d7b)


- [x] [6a2da7efb Configurable swift-account for the ramdisk logs](https://github.com/sapcc/ironic/commit/6a2da7efb)


- [ ] [752a8e953 Merge pull request #28 from openstack/stable/2023.1](https://github.com/sapcc/ironic/commit/752a8e953)
  -> Merge commit, not cherry-picked
