### PR TITLE
Use service auth for Neutron port operations

### DIFF
--- a/ironic/common/neutron.py
+++ b/ironic/common/neutron.py
@@ -261,7 +261,7 @@ def add_ports_to_network(task, network_uuid, security_groups=None):
     :raises: NetworkError
     :returns: a dictionary in the form {port.uuid: neutron_port['id']}
     """
-    client = get_client(context=task.context)
+    client = get_client(context=task.context, auth_from_config=True)
     node = task.node
     add_all_ports = CONF.neutron.add_all_ports
 
@@ -414,7 +414,7 @@ def remove_neutron_ports(task, params):
     :param params: Dict of params to filter ports.
     :raises: NetworkError
     """
-    client = get_client(context=task.context)
+    client = get_client(context=task.context, auth_from_config=True)
     node_uuid = task.node.uuid
 
     try:


### PR DESCRIPTION
When a user triggers a manual operation like cleaning, most requests towards the Neutron API are made with the authentication parameters provided by the user's context. In case of port creation this can lead to ports being created with an unexpected project id (taken from the project scope of the current user). To prevent this, we now use the service credentials from config for add_ports_to_network() and remove_neutron_ports().

Closes-Bug: #2121702
Change-Id: I0669782bacfb95b42dfa300e4f91ece62893847c

---
Link to upstream patch in gerrit: https://review.opendev.org/c/openstack/ironic/+/989431